### PR TITLE
Dispose of the wizard dock pairs when the user loads in a new object

### DIFF
--- a/POD Source Code/CSharpBackendTempSolutionForPOD4Point5/CSharpBackendWithR/AHatAnalysisRControl.cs
+++ b/POD Source Code/CSharpBackendTempSolutionForPOD4Point5/CSharpBackendWithR/AHatAnalysisRControl.cs
@@ -343,7 +343,9 @@ namespace CSharpBackendWithR
             
             return AllLinearTestResults;
         }
-        
+        /// <summary>
+        /// method is used for debugging only
+        /// </summary>
         public void ShowResults()
         {
             myREngine.Evaluate("newSRAnalysis$plotSimdata(newSRAnalysis$getLinearModel())");

--- a/POD Source Code/CSharpBackendTempSolutionForPOD4Point5/CSharpBackendWithR/ParentAnalysisObject.cs
+++ b/POD Source Code/CSharpBackendTempSolutionForPOD4Point5/CSharpBackendWithR/ParentAnalysisObject.cs
@@ -8,7 +8,7 @@ namespace CSharpBackendWithR
     /// This class contains analysis metrics that are shared by both hit/miss and signal response analyses.
     /// </summary>
     [Serializable]
-    public class ParentAnalysisObject
+    abstract public class ParentAnalysisObject
     {
         //may have to adjust this later
         protected double Pod_all;
@@ -39,7 +39,7 @@ namespace CSharpBackendWithR
         /// <summary>
         /// sets default values for fields that are shared by both AHat and HitMiss data
         /// </summary>
-        public ParentAnalysisObject()
+        protected ParentAnalysisObject()
         {
             Count = 0; //the original number of data points in a given analysis
             //max and min crack sizes


### PR DESCRIPTION
While this greatly reduces the number of user objects  the application is using, there is still a memory leak somewhere that cause the user objects to be way higher than they should be. Thus, the branch will not be deleted.