### PR TITLE
Dispose of the wizard Dock pairs when the user closes a larger project and reloads another one

### DIFF
--- a/POD Source Code/POD v4/MainForm.cs
+++ b/POD Source Code/POD v4/MainForm.cs
@@ -219,6 +219,9 @@ namespace POD
             _loader.Close();
 
             _loader.Dispose();
+
+            load_R.Dispose();
+
         }
 
         void _dockMgr_AllWizardsClosed(object sender, EventArgs e)

--- a/POD Source Code/WizardController/WizardController.cs
+++ b/POD Source Code/WizardController/WizardController.cs
@@ -125,7 +125,7 @@ namespace POD
         {
             pair.Dock.Dispose();
             pair.Wizard.DeleteSteps();
-            pair.Wizard.DeleteTreeNodes();
+            //pair.Wizard.DeleteTreeNodes();
         }
 
         // <summary>

--- a/POD Source Code/WizardController/WizardController.cs
+++ b/POD Source Code/WizardController/WizardController.cs
@@ -117,6 +117,17 @@ namespace POD
             AddAnalysis(myAnalysis, null);
         }
 
+        /// <summary>
+        /// Disposes of all the user objects in both the dock and wizard
+        /// </summary>
+        /// <param name="pair"></param>
+        private void DisposeWizardDockPair(WizardDockPair pair)
+        {
+            pair.Dock.Dispose();
+            pair.Wizard.DeleteSteps();
+            pair.Wizard.DeleteTreeNodes();
+        }
+
         // <summary>
         /// Removes the analysis from the project.
         /// </summary>
@@ -133,21 +144,6 @@ namespace POD
                 _wizards.Remove(dock);
 
                 dock.Dock.Close();
-                /*
-               if (!dock.Dock.Step.IsDisposed)
-               {
-                   dock.Dock.Close();
-               }
-               
-                try
-                {
-                    dock.Dock.Close();
-                }
-                catch (ObjectDisposedException)
-                {
-                    //
-                }
-                */
             }
         }
 
@@ -160,6 +156,8 @@ namespace POD
             if (_wizards.Project != null)
             {
                 _wizards.Project.Dock.Close();
+                _wizards.Project.Dock.Dispose();
+                _wizards.Project.Wizard.DeleteProjWizardSteps();
                 _wizards.Project = null;
             }
         }
@@ -1108,12 +1106,14 @@ namespace POD
         public void ClearEverything()
         {
             DeleteProject();
-
+            
             var analyses = new List<Analysis>();
 
             foreach (WizardDockPair pair in _wizards)
             {
                 analyses.Add(pair.Analysis);
+                //release all the user objects for the wizard dock pair
+                DisposeWizardDockPair(pair);
             }
 
             foreach(Analysis analysis in analyses)

--- a/POD Source Code/Wizards/Wizard.cs
+++ b/POD Source Code/Wizards/Wizard.cs
@@ -283,6 +283,35 @@ namespace POD.Wizards
         {
             _list = new WizardStepList();
         }
+        public void DeleteTreeNodes()
+        {
+            foreach(TreeNode node in Source.ProgressStepListNode.Nodes)
+            {
+                if(node != null)
+                {
+                    node.Remove();
+                }
+            }
+        }
+        public void DeleteProjWizardSteps()
+        {
+            foreach (var step in _list)
+            {
+                
+                foreach (Control control in step.Controls)
+                {
+                    control.Dispose();
+                }
+                step.ActionBar.Dispose();
+                step.Title.Dispose();
+                step.Dispose();
+            }
+            DeleteTreeNodes();
+        }
+        /// <summary>
+        /// disposes of the steps when a wizard is closed to free up user objects in the application
+        /// The main chart CANNOT be disposed without issues (throws disposed exception when the wizard is reloaded)
+        /// </summary>
         public void DeleteSteps()
          {
             foreach(var step in _list)

--- a/POD Source Code/Wizards/Wizard.cs
+++ b/POD Source Code/Wizards/Wizard.cs
@@ -285,6 +285,8 @@ namespace POD.Wizards
         }
         public void DeleteTreeNodes()
         {
+            if (Source.ProgressStepListNode == null)
+                return;
             foreach(TreeNode node in Source.ProgressStepListNode.Nodes)
             {
                 if(node != null)

--- a/POD Source Code/Wizards/Wizard.cs
+++ b/POD Source Code/Wizards/Wizard.cs
@@ -148,6 +148,15 @@ namespace POD.Wizards
         }
 
         /// <summary>
+        /// disposes of the steps when a wizard is closed to free up user objects in the application
+        /// The main chart CANNOT be disposed without issues (throws disposed exception when the wizard is reloaded)
+        /// </summary>
+        public virtual void DeleteSteps()
+        {
+
+        }
+
+        /// <summary>
         /// Add a new Step to the end of the Step List.
         /// </summary>
         /// <param name="myStep">the Step to add</param>
@@ -309,79 +318,6 @@ namespace POD.Wizards
                 step.Dispose();
             }
             DeleteTreeNodes();
-        }
-        /// <summary>
-        /// disposes of the steps when a wizard is closed to free up user objects in the application
-        /// The main chart CANNOT be disposed without issues (throws disposed exception when the wizard is reloaded)
-        /// </summary>
-        public void DeleteSteps()
-         {
-            foreach(var step in _list)
-            {
-                //step.Panel.Dispose();
-                //step.Dispose();
-                if (step is Steps.HitMissNormalSteps.ChooseTransformStep ||
-                    step is Steps.HitMissNormalSteps.DocumentRemovedStep ||
-                    step is Steps.AHatVsANormalSteps.ChooseTransformStep ||
-                    step is Steps.AHatVsANormalSteps.DocumentRemovedStep)
-                {
-                    step.Dispose();
-                }
-                else if (step is Steps.HitMissNormalSteps.FullRegressionStep ||
-                    step is Steps.AHatVsANormalSteps.FullRegressionStep)
-                {
-                    // you cannot outright dispose of the entire fullregression step
-                    // if you try to and reopen the analysis, the mainchart with still be disposed
-                    // when raiseanalysisdone is invoked
-                    if(step is Steps.HitMissNormalSteps.FullRegressionStep)
-                        ((Steps.HitMissNormalSteps.FullRegressionPanel)step.Panel).DisposeAllExceptMainChart();
-                    else if(step is Steps.AHatVsANormalSteps.FullRegressionStep)
-                        ((Steps.AHatVsANormalSteps.FullRegressionPanel)step.Panel).DisposeAllExceptMainChart();
-                    step.ActionBar.Dispose();
-                    step.Title.Dispose();
-                    foreach (Control control in step.Controls)
-                    {
-                        control.Dispose();
-                    }
-                    //((POD.Wizards.RegressionPanel)step.Panel).MainChart.Series.Dispose();
-                    //step.Site.Container.Dispose();
-                    //step.Region.Dispose();
-                    /*
-                    if (tempStep is Steps.HitMissNormalSteps.DocumentRemovedStep)
-                    {
-                        ((Steps.HitMissNormalSteps.FullRegressionPanel)step.Panel).DisposeAllExceptMainChart();
-                        step.ActionBar.Dispose();
-                        step.Title.Dispose();
-                        foreach(Control control in step.Controls)
-                        {
-                            control.Dispose();
-                        }
-                        continue;
-                    }
-                    else if (tempStep is Steps.AHatVsANormalSteps.DocumentRemovedStep)
-                    {
-                        throw new NotImplementedException();
-                    }
-
-                    ((POD.Wizards.RegressionPanel)step.Panel).MainChart.Dispose();
-                    //((POD.Wizards.RegressionPanel)step.Panel).MainChart = null;
-                    List<DataPointChart> tempDataList = ((POD.Wizards.RegressionPanel)step.Panel).SideCharts;
-                    for (int i = 0; i < tempDataList.Count; i++)
-                    {
-                        tempDataList[i].Dispose();
-                        tempDataList[i] = null;
-                    }
-                    ((POD.Wizards.RegressionPanel)step.Panel).Dispose();
-                    //step.Panel.Controls.Clear();
-                    //step.Panel = null;
-                    //step.Panel.Dispose();
-                    step.Dispose();
-                    */
-                }
-            }
-            //the list needs to retain the disposed objects
-            //the steps will be overwritten if the given analysis is reopened
-            //_list.Clear();
         }
         #endregion
 

--- a/POD Source Code/Wizards/Wizard.cs
+++ b/POD Source Code/Wizards/Wizard.cs
@@ -292,6 +292,7 @@ namespace POD.Wizards
         {
             _list = new WizardStepList();
         }
+        /*
         public void DeleteTreeNodes()
         {
             if (Source.ProgressStepListNode == null)
@@ -304,6 +305,7 @@ namespace POD.Wizards
                 }
             }
         }
+        */
         public void DeleteProjWizardSteps()
         {
             foreach (var step in _list)
@@ -317,7 +319,7 @@ namespace POD.Wizards
                 step.Title.Dispose();
                 step.Dispose();
             }
-            DeleteTreeNodes();
+            //DeleteTreeNodes();
         }
         #endregion
 

--- a/POD Source Code/Wizards/Wizards/AHatvsAAnalysis/AHatvsANormalWizard.cs
+++ b/POD Source Code/Wizards/Wizards/AHatvsAAnalysis/AHatvsANormalWizard.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 using POD.Analyze;
 using POD.Wizards.Steps.FullAnalysisProjectSteps;
 
@@ -27,6 +28,31 @@ namespace POD.Wizards
             CreateWizardProgressStepListNode();
 
             CurrentStep = FirstStep;
+        }
+
+        public override void DeleteSteps()
+        {
+            foreach (var step in _list)
+            {
+                if (step is Steps.AHatVsANormalSteps.ChooseTransformStep ||
+                    step is Steps.AHatVsANormalSteps.DocumentRemovedStep)
+                {
+                    step.Dispose();
+                }
+                else if (step is Steps.AHatVsANormalSteps.FullRegressionStep)
+                {
+                    // you cannot outright dispose of the entire fullregression step
+                    // if you try to and reopen the analysis, the mainchart with still be disposed
+                    // when raiseanalysisdone is invoked
+                    ((Steps.AHatVsANormalSteps.FullRegressionPanel)step.Panel).DisposeAllExceptMainChart();
+                    step.ActionBar.Dispose();
+                    step.Title.Dispose();
+                    foreach (Control control in step.Controls)
+                    {
+                        control.Dispose();
+                    }
+                }
+            }
         }
     }
 }

--- a/POD Source Code/Wizards/Wizards/HitMissAnalysis/HitMissNormalWizard.cs
+++ b/POD Source Code/Wizards/Wizards/HitMissAnalysis/HitMissNormalWizard.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 using POD.Analyze;
 using POD.Wizards.Steps.FullAnalysisProjectSteps;
 
@@ -22,6 +23,34 @@ namespace POD.Wizards
             CreateWizardProgressStepListNode();
 
             CurrentStep = FirstStep;
+        }
+        public override void DeleteSteps()
+        {
+                foreach (var step in _list)
+                {
+
+                    if (step is Steps.HitMissNormalSteps.ChooseTransformStep ||
+                        step is Steps.HitMissNormalSteps.DocumentRemovedStep)
+                    {
+                        step.Dispose();
+                    }
+                    else if (step is Steps.HitMissNormalSteps.FullRegressionStep)
+                    {
+                        // you cannot outright dispose of the entire fullregression step
+                        // if you try to and reopen the analysis, the mainchart with still be disposed
+                        // when raiseanalysisdone is invoked
+                        ((Steps.HitMissNormalSteps.FullRegressionPanel)step.Panel).DisposeAllExceptMainChart();
+                        ((Steps.HitMissNormalSteps.FullRegressionPanel)step.Panel).WizActionBar.Dispose();
+                        step.ActionBar.Dispose();
+                        
+                        step.Title.Dispose();
+                        foreach (Control control in step.Controls)
+                        {
+                            control.Dispose();
+                        }
+                        
+                    }
+                }
         }
     }
 }


### PR DESCRIPTION
While this greatly reduces the number of user objects the application is using, there is still a memory leak somewhere that cause the user objects to be way higher than they should be. Thus, the branch will not be deleted.